### PR TITLE
BE-Benutzer synchronisieren bei FE-Mitglieder "Passwort vergessen" Modul

### DIFF
--- a/system/modules/UserMemberBridge/UserMemberSyncronizer.php
+++ b/system/modules/UserMemberBridge/UserMemberSyncronizer.php
@@ -36,6 +36,18 @@
  * @package    UserMemberBridge
  */
 class UserMemberSyncronizer extends Backend {
+	 /**
+	 * mySetNewPassword - Hook to syncronize member to user when password was changed by using the FE module 'Passwort vergessen'
+	 */
+
+        public function mySetNewPasswordHook($objUser, $strPassword)
+	{
+  	         if (!$objUser instanceof DataContainer && $objUser!= null) {
+			$this->syncMemberWithUser($objUser);
+	         }
+        $this->log('BE-User updated after FE-Member password lost' .'('.$objUser.')','mySetNewPasswordHook', TL_ACCESS);
+        }
+	
 	/**
 	 * Syncronizes all fields from user to member
 	 * @param DataContainer

--- a/system/modules/UserMemberBridge/config/config.php
+++ b/system/modules/UserMemberBridge/config/config.php
@@ -33,7 +33,12 @@
 // Extend backend module configuration for global operation
 $GLOBALS['BE_MOD']['accounts']['user']['createUserForMember'] = array('UserMemberSyncronizer', 'createUserForMember');
 $GLOBALS['BE_MOD']['accounts']['member']['createMemberForUser'] = array('UserMemberSyncronizer', 'createMemberForUser');
- 
+
+/**
+ * Hook at setNewPassword
+ */
+$GLOBALS['TL_HOOKS']['setNewPassword'][] = array('UserMemberSyncronizer', 'mySetNewPasswordHook');
+
 /**
  * to fix height of style class w50 in backend
  */


### PR DESCRIPTION
Die Erweiterung ist super, nur fehlte mir die Funktion, dass BE-Benutzer
synchronisiert werden wenn sich ein zugehöriges FE-Mitglied über die
Funktion / Module 'Passwort vergessen' ein neues Passwort zulegt.
Hierbei wird bis jetzt das Passwort des BE-Benutzer nicht
synchronisiert.

Lösung mittels setNewPassword - Hook: