### PR TITLE
Überlappung in den Systemeinstellungen verhindern

### DIFF
--- a/system/modules/UserMemberBridge/dca/tl_settings.php
+++ b/system/modules/UserMemberBridge/dca/tl_settings.php
@@ -40,7 +40,7 @@ $GLOBALS['TL_DCA']['tl_settings']['fields']['userMemberBridgeSyncFields'] = arra
 	'inputType'               => 'checkbox',
 	'options'                 => array('username', 'name', 'email', 'password'),
 	'reference'               => &$GLOBALS['TL_LANG']['tl_settings']['userMemberBridgeSyncFields'],
-	'eval'                    => array('multiple'=>true, 'mandatory'=>true, 'tl_class'=>'w50')
+	'eval'                    => array('multiple'=>true, 'mandatory'=>true, 'tl_class'=>'clr w50')
 );
 $GLOBALS['TL_DCA']['tl_settings']['fields']['userMemberBridgeUsernameFormat'] = array(
 	'label'                   => &$GLOBALS['TL_LANG']['tl_settings']['userMemberBridgeUsernameFormat'],


### PR DESCRIPTION
Es fehlte ein Clearing im erstem Feld, sonst haut's die Admin-Sicherheit-Checkbox über die Auswahl der Synchronisationsfelder. siehe Screenshot 

![bildschirmfoto 2017-01-17 um 15 36 58](https://cloud.githubusercontent.com/assets/1337412/22024699/1d819aea-dccb-11e6-9408-601efbfa33ea.png)
